### PR TITLE
Change to calendar-independent schedule

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         lesson: [swcarpentry/shell-novice, datacarpentry/r-intro-geospatial, librarycarpentry/lc-git]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         experimental: [false]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             os-name: Linux
           - os: macos-latest
             os-name: macOS
@@ -31,12 +31,12 @@ jobs:
           - lesson: datacarpentry/astronomy-python
             lesson-name: (DC) Foundations of Astronomical Data Science
             experimental: true
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             os-name: Linux
           - lesson: carpentries/lesson-example
             lesson-name: (CP) Lesson Example
             experimental: false
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             os-name: Linux
     defaults:
       run:
@@ -176,7 +176,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd || echo "Nothing to update"
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "22.04"), sep = "\n")')
 
       - run: make site
         working-directory: lesson

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-website:
     if: ${{ !endsWith(github.repository, '/styles') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -19,11 +19,11 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -86,7 +86,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd || echo "Nothing to update"
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "22.04"), sep = "\n")')
 
       - name: Render the markdown and confirm that the site can be built
         run: make site


### PR DESCRIPTION
Replace the 2023 schedule (one day, 9:30am start) with a clock-independent schedule, before I figure out if there's a way to get it to show a two-day schedule (to better reflect the 2024 plan).